### PR TITLE
Fix unhandled exception from parsing tray file

### DIFF
--- a/test_phile/test_tray/test_gui.py
+++ b/test_phile/test_tray/test_gui.py
@@ -411,6 +411,28 @@ class TestGuiIconList(unittest.TestCase):
         _logger.debug('End of test.')
 
     @unittest.mock.patch(
+        'phile.tray.gui.QSystemTrayIcon', SystemTrayIcon
+    )
+    def test_show_with_bad_file(self) -> None:
+        """
+        Show ignores badly structured files.
+
+        There is not much we can do about it as a reader.
+        """
+        # Create a tray.
+        tray = TrayFile(name='VeCat', configuration=self.configuration)
+        tray.icon_name = 'phile-tray-empty'
+        tray.text_icon = 'A'
+        tray.save()
+        with tray.path.open('a+') as file_stream:
+            file_stream.write('Extra text.')
+        # Check that they are all detected when showing the tray icons.
+        gui_icon_list = self.gui_icon_list
+        with self.assertWarns(UserWarning):
+            gui_icon_list.show()
+        self.assertEqual(len(gui_icon_list.tray_children()), 0)
+
+    @unittest.mock.patch(
         'phile.tray.gui.QIcon.fromTheme', q_icon_from_theme
     )
     @unittest.mock.patch(

--- a/test_phile/test_tray/test_tmux.py
+++ b/test_phile/test_tray/test_tmux.py
@@ -499,6 +499,24 @@ class TestIconList(unittest.TestCase):
         self.icon_list.load(year_tray_file)
         self.control_mode.send_command.assert_not_called()
 
+    def test_dispatch_with_bad_file(self) -> None:
+        """
+        Dispatch ignores badly structured files.
+
+        There is not much we can do about it as a reader.
+        """
+        tray_file = TrayFile(
+            configuration=self.configuration, name='month'
+        )
+        tray_file.text_icon = 'ABC'
+        tray_file.save()
+        with tray_file.path.open('a+') as file_stream:
+            file_stream.write('\nNot JSON.')
+        with self.assertWarns(UserWarning):
+            self.icon_list.dispatch(
+                watchdog.events.FileCreatedEvent(tray_file.path)
+            )
+
     def test_show_with_existing_files(self) -> None:
         """
         Showing should display existing tray files.


### PR DESCRIPTION
Tray files represent items to display in the system tray.
They are read and parsed for information on what to display.
It is possible for the tray files to be modified while the read occurs,
leading to an exception being raised.

The exceptions are now handled.
They are ignored after logging a warning.
There is little we can do from the reading side.

Tray file parsing now also caches the entire file before parsing,
to reduce the chance of the file being changed before reading completes.

Adds unit tests for loading bad tray files.

Fixes: https://github.com/BoniLindsley/phile/issues/1