### PR TITLE
Use FileSystemMonitor not Observer in GUI classes

### DIFF
--- a/phile/notify/gui.py
+++ b/phile/notify/gui.py
@@ -25,7 +25,7 @@ from phile.PySide2_extras.posix_signal import (
     install_noop_signal_handler, PosixSignal
 )
 from phile.PySide2_extras.watchdog_wrapper import (
-    FileSystemMonitor, FileSystemSignalEmitter, Observer
+    FileSystemMonitor, FileSystemSignalEmitter
 )
 
 _logger = logging.getLogger(
@@ -241,20 +241,17 @@ class MainWindow(QMainWindow):
         self,
         *args,
         configuration: Configuration = None,
-        observer: Observer = None,
+        file_system_monitor: FileSystemMonitor = None,
         **kwargs
     ):
         super().__init__(*args, **kwargs)
         # Create the GUI for displaying notifications.
         mdi_area = NotificationMdi()
         self.setCentralWidget(mdi_area)
-        # Attach a file monitor to it as a child
-        # for automatic life-time management.
-        if observer is None:
-            observer = Observer()
-        self._file_system_monitor = FileSystemMonitor(
-            mdi_area, _watchdog_observer=observer
-        )
+        # Use a monitor get file system events.
+        if file_system_monitor is None:
+            file_system_monitor = FileSystemMonitor(mdi_area)
+        self._file_system_monitor = file_system_monitor
         # Figure out where notifications are and their suffix.
         if configuration is None:
             configuration = Configuration()

--- a/phile/tray/gui.py
+++ b/phile/tray/gui.py
@@ -27,7 +27,7 @@ from phile.PySide2_extras.posix_signal import (
     install_noop_signal_handler, PosixSignal
 )
 from phile.PySide2_extras.watchdog_wrapper import (
-    FileSystemMonitor, FileSystemSignalEmitter, Observer
+    FileSystemMonitor, FileSystemSignalEmitter
 )
 
 _logger = logging.getLogger(
@@ -209,7 +209,7 @@ class GuiIconList(QObject):
         self,
         *args,
         configuration: Configuration = None,
-        observer: Observer = None,
+        file_system_monitor: FileSystemMonitor = None,
         **kwargs
     ) -> None:
 
@@ -221,13 +221,10 @@ class GuiIconList(QObject):
         super().__init__(*args, **kwargs)
         # Keep track of GUI icons created.
         self.tray_files: typing.List[TrayFile] = []
-        # Attach a file monitor to it as a child
-        # for automatic life-time management.
-        if observer is None:
-            observer = Observer()
-        self._file_system_monitor = FileSystemMonitor(
-            self, _watchdog_observer=observer
-        )
+        # Use a monitor get file system events.
+        if file_system_monitor is None:
+            file_system_monitor = FileSystemMonitor(self)
+        self._file_system_monitor = file_system_monitor
         # Figure out where tray files are and their suffix.
         if configuration is None:
             configuration = Configuration()


### PR DESCRIPTION
GUI classes, such as `MainWindow` and `GuiIconList`,
use watchdog `Observer`-s to monitor for file changes.
The `Observer`-s dispatch events and call handlers in worker threads
to allow the GUI classes to respond to file changes.
However, these event handlers cannot call GUI functions,
because GUI functions are typically not thread-safe.
So the GUI classes use the `Observer`-s
by wrapping them in `FileSystemMonitor`-s to manage their lifetimes,
and `FileSystemSignalEmitter`
which translate the watchdog events into GUI signals
in order to handle them inside the GUI event loop.

The GUI classes did indeed take an `Observer` instance in its parameter.
Since `FileSystemMonitor` takes ownership of the given `Observer`,
it means the GUI classes do as well,
and so sharing the same observer with multple GUI classes
is not supported.

The GUI classes now take a `FileSystemMonitor` argument
instead of `Observer` to allow for sharing with other GUI classes.
This is in preparation for displaying multiple such GUI classes
in the same application.

Fixes: https://github.com/BoniLindsley/phile/issues/6